### PR TITLE
Add batch number from NCIT

### DIFF
--- a/src/main/resources/ncit.iris
+++ b/src/main/resources/ncit.iris
@@ -1,0 +1,3 @@
++(http://purl.obolibrary.org/obo/IAO_0000027):http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C104504 batch number
+
+

--- a/src/main/resources/ncit.props
+++ b/src/main/resources/ncit.props
@@ -1,0 +1,3 @@
+owl=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl
+iris=ncit.iris
+slimmed=http://purl.enanomapper.org/onto/external/ncit-slim.owl


### PR DESCRIPTION
Subclass of data item (IAO). Necessary for NANoREG mapping from database schema.
